### PR TITLE
Fix code scanning alert no. 1: Uncontrolled data used in path expression

### DIFF
--- a/internal/routes/v1.go
+++ b/internal/routes/v1.go
@@ -118,6 +118,13 @@ func (v *V1) PostApplications(w http.ResponseWriter, r *http.Request) {
 func ServeIcon(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	filename := vars["filename"]
+
+	// Validate filename to ensure it does not contain any path separators or parent directory references
+	if strings.Contains(filename, "/") || strings.Contains(filename, "\\") || strings.Contains(filename, "..") {
+		http.Error(w, "Invalid file name", http.StatusBadRequest)
+		return
+	}
+
 	filePath := filepath.Join(c.Config.Icons.CacheDir, "icons", filename)
 
 	log.Printf("Serving icon %s", filePath)


### PR DESCRIPTION
Fixes [https://github.com/mvdkleijn/homedash/security/code-scanning/1](https://github.com/mvdkleijn/homedash/security/code-scanning/1)

To fix the problem, we need to validate the `filename` to ensure it does not contain any path separators or parent directory references. This can be done by checking for the presence of "/" or "\\" characters and ".." sequences in the `filename`. If any of these are found, we should return an error response.

**Steps to fix:**
1. Add validation for the `filename` to ensure it does not contain any path separators or parent directory references.
2. If the validation fails, return an HTTP error response.
3. If the validation passes, proceed with the existing logic to serve the file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
