### PR TITLE
Fix code scanning alert no. 2: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/internal/config/icons.go
+++ b/internal/config/icons.go
@@ -69,6 +69,10 @@ func unzipFile(src, dest string) error {
 	defer reader.Close()
 
 	for _, file := range reader.File {
+		if strings.Contains(file.Name, "..") {
+			log.Warn().Str("file", file.Name).Msg("skipping file with invalid path")
+			continue
+		}
 		path := filepath.Join(dest, file.Name)
 		if file.FileInfo().IsDir() {
 			os.MkdirAll(path, os.ModePerm)


### PR DESCRIPTION
Fixes [https://github.com/mvdkleijn/homedash/security/code-scanning/2](https://github.com/mvdkleijn/homedash/security/code-scanning/2)

To fix the problem, we need to ensure that the paths extracted from the zip file do not contain any directory traversal elements like `..`. This can be achieved by checking the path components and ensuring they do not navigate outside the intended directory.

- We will add a check to ensure that the `file.Name` does not contain any `..` elements.
- If the path is found to be safe, we proceed with the extraction; otherwise, we skip the file and log a warning.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
